### PR TITLE
Quote parameter default value

### DIFF
--- a/files/acme-controller-template.yml
+++ b/files/acme-controller-template.yml
@@ -16,7 +16,7 @@ parameters:
   name: DOCKER_IMAGE_TAG
   value: latest
 - name: REPLICA_COUNT
-  value: 1
+  value: "1"
 objects:
 - apiVersion: v1
   kind: ClusterRole


### PR DESCRIPTION
OpenShift template parameters are always strings. It's therefore
necessary to quote an integer, i.e. 1 becomes "1".