### PR TITLE
Lower the pods resource request and limits

### DIFF
--- a/files/acme-controller-template.yml
+++ b/files/acme-controller-template.yml
@@ -154,11 +154,11 @@ objects:
           - --loglevel=${OPENSHIFT_ACME_LOGLEVEL}
           resources:
             limits:
-              cpu: '500m'
+              cpu: '100m'
               memory: '512Mi'
             requests:
-              cpu: '500m'
-              memory: '512Mi'
+              cpu: '20m'
+              memory: '192Mi'
         serviceAccountName: acme-controller
     triggers:
     - type: ImageChange


### PR DESCRIPTION
Checking the metrics showed that the cpu request and limits are
far too high, even on a cluster with many certificates.

Lowering also the memory request as small clusters have a utilisation
of below 100Mi and bigger clusters around 200Mi base.