### PR TITLE
Add support to override default RSA key bit size for new certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ One of:
 | appuio_openshift_acme_loglevel         | `4`                               | Loglevel (0-10)                         |
 | appuio_openshift_acme_http_proxy       | `''`                              | HTTP and HTTPS proxy                    |
 | appuio_openshift_acme_no_proxy         | `''`                              | List of domain elements or IP addresses |
+| appuio_openshift_acme_default_rsa_key_bit_size | `4096`                    | Default RSA key bit size for new certificates |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ appuio_openshift_acme_docker_image: quay.io/tnozicka/openshift-acme
 appuio_openshift_acme_docker_image_tag: controller-0.9
 appuio_openshift_acme_exposer_image: quay.io/tnozicka/openshift-acme
 appuio_openshift_acme_exposer_image_tag: exposer-0.9
+appuio_openshift_acme_default_rsa_key_bit_size: 4096

--- a/files/acme-controller-template.yml
+++ b/files/acme-controller-template.yml
@@ -21,6 +21,8 @@ parameters:
 - description: HTTP proxy exclusions
   name: NO_PROXY
   value: ""
+- description: Default RSA key bit size for new certificates
+  name: RSA_KEY_BIT_SIZE
 objects:
 - apiVersion: v1
   kind: ClusterRole
@@ -158,6 +160,7 @@ objects:
           args:
           - --exposer-image=${EXPOSER_IMAGE}:${EXPOSER_IMAGE_TAG}
           - --loglevel=${OPENSHIFT_ACME_LOGLEVEL}
+          - --cert-default-rsa-key-bit-size=${RSA_KEY_BIT_SIZE}
           resources:
             limits:
               cpu: '100m'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,7 @@
       EXPOSER_IMAGE_TAG: "{{ appuio_openshift_acme_exposer_image_tag | mandatory }}"
       HTTP_PROXY: "{{ appuio_openshift_acme_http_proxy | default(omit) }}"
       NO_PROXY: "{{ appuio_openshift_acme_no_proxy | default(omit) }}"
+      RSA_KEY_BIT_SIZE: "{{ appuio_openshift_acme_default_rsa_key_bit_size | mandatory }}"
 
 - name: Delete temp directory
   file:


### PR DESCRIPTION
This PR closes an issue we raised because some CDNs, don't support private keys bigger than 2048 (default is 4096).