### PR TITLE
Expose controller CPU/memory requests and limits

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,7 @@ appuio_openshift_acme_docker_image_tag: controller-0.9
 appuio_openshift_acme_exposer_image: quay.io/tnozicka/openshift-acme
 appuio_openshift_acme_exposer_image_tag: exposer-0.9
 appuio_openshift_acme_default_rsa_key_bit_size: 4096
+appuio_openshift_acme_controller_cpu_requests: 20m
+appuio_openshift_acme_controller_cpu_limits: 100m
+appuio_openshift_acme_controller_memory_requests: 192Mi
+appuio_openshift_acme_controller_memory_limits: 512Mi

--- a/files/acme-controller-template.yml
+++ b/files/acme-controller-template.yml
@@ -23,6 +23,14 @@ parameters:
   value: ""
 - description: Default RSA key bit size for new certificates
   name: RSA_KEY_BIT_SIZE
+- description: Controller CPU requests
+  name: CONTROLLER_CPU_REQUESTS
+- description: Controller CPU limits
+  name: CONTROLLER_CPU_LIMITS
+- description: Controller memory requests
+  name: CONTROLLER_MEMORY_REQUESTS
+- description: Controller memory limits
+  name: CONTROLLER_MEMORY_LIMITS
 objects:
 - apiVersion: v1
   kind: ClusterRole
@@ -163,11 +171,11 @@ objects:
           - --cert-default-rsa-key-bit-size=${RSA_KEY_BIT_SIZE}
           resources:
             limits:
-              cpu: '100m'
-              memory: '512Mi'
+              cpu: ${CONTROLLER_CPU_LIMITS}
+              memory: ${CONTROLLER_MEMORY_LIMITS}
             requests:
-              cpu: '20m'
-              memory: '192Mi'
+              cpu: ${CONTROLLER_CPU_REQUESTS}
+              memory: ${CONTROLLER_MEMORY_REQUESTS}
           env:
             - name: HTTP_PROXY
               value: ${HTTP_PROXY}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,10 @@
       HTTP_PROXY: "{{ appuio_openshift_acme_http_proxy | default(omit) }}"
       NO_PROXY: "{{ appuio_openshift_acme_no_proxy | default(omit) }}"
       RSA_KEY_BIT_SIZE: "{{ appuio_openshift_acme_default_rsa_key_bit_size | mandatory }}"
+      CONTROLLER_CPU_REQUESTS: "{{ appuio_openshift_acme_controller_cpu_requests | mandatory }}"
+      CONTROLLER_CPU_LIMIITS: "{{ appuio_openshift_acme_controller_cpu_limits | mandatory }}"
+      CONTROLLER_MEMORY_REQUESTS: "{{ appuio_openshift_acme_controller_memory_requests | mandatory }}"
+      CONTROLLER_MEMORY_LIMITS: "{{ appuio_openshift_acme_controller_memory_limits | mandatory }}"
 
 - name: Delete temp directory
   file:


### PR DESCRIPTION
This allows customizing the controller's CPU and/or memory resources and/or limits. This may be useful on clusters where there are large amounts of managed routes.

We've observed that the acme-controller pod gets OOMKilled regularly with the default memory limit of 512Mi on clusters which have multiple thousand routes configured for LetsEncrypt.